### PR TITLE
Feature/notify undefined sort or filter

### DIFF
--- a/src/Apitizer/Support/FetchSpecFactory.php
+++ b/src/Apitizer/Support/FetchSpecFactory.php
@@ -150,6 +150,10 @@ class FetchSpecFactory
                 $sort->setOrder($parserSort->getOrder());
                 $selectedSorting[] = $sort;
             }
+            if (!isset($availableSorting[$parserSort->getField()])) {
+                $execption = new InvalidInputException("The input you are trying to sort on does not exist");
+                $this->queryBuilder->getExceptionStrategy()->handle($this->queryBuilder, $execption);
+            }
         }
 
         return $selectedSorting;
@@ -169,6 +173,10 @@ class FetchSpecFactory
                     $filter = $availableFilters[$name];
                     $filter->setValue($filterInput);
                     $selectedFilters[] = $filter;
+                }
+                if (!isset($availableFilters[$name])) {
+                    $execption = new InvalidInputException("This filter does not exist");
+                    $this->queryBuilder->getExceptionStrategy()->handle($this->queryBuilder, $execption);
                 }
             } catch (InvalidInputException $e) {
                 $this->queryBuilder->getExceptionStrategy()->handle(

--- a/tests/Feature/QueryBuilder/PaginationTest.php
+++ b/tests/Feature/QueryBuilder/PaginationTest.php
@@ -28,7 +28,7 @@ class PaginationTest extends TestCase
         factory(User::class, 2)->create();
         $request = $this->request()
                         ->fields('id')
-                        ->filter('empty', 1)
+                        ->filter('active', 1)
                         ->sort('id')
                         ->limit(1)
                         ->make();
@@ -38,7 +38,7 @@ class PaginationTest extends TestCase
         $this->assertNotNull($paginator->nextPageUrl());
         $this->paginatorLinkContainsString($paginator, Apitizer::getFieldKey() . '=id');
         $this->paginatorLinkContainsString($paginator, Apitizer::getSortKey() . '=id');
-        $this->paginatorLinkContainsString($paginator, Apitizer::getFilterKey() . '[empty]=1');
+        $this->paginatorLinkContainsString($paginator, Apitizer::getFilterKey() . '[active]=1');
         $this->paginatorLinkContainsString($paginator, 'limit=1');
     }
 

--- a/tests/Feature/database/factories/UserFactory.php
+++ b/tests/Feature/database/factories/UserFactory.php
@@ -8,6 +8,7 @@ $factory->define(User::class, function (Faker $faker, array $attributes) {
     return [
         'name'  => $faker->name,
         'email' => $faker->email,
+        'active' => 1,
     ];
 });
 

--- a/tests/Feature/database/migrations/2019_12_24_182300_create_users_table.php
+++ b/tests/Feature/database/migrations/2019_12_24_182300_create_users_table.php
@@ -18,6 +18,7 @@ class CreateUsersTable extends Migration
             $table->uuid('uuid');
             $table->string('name');
             $table->string('email');
+            $table->boolean('active');
             $table->string('should_reset_password')->default(false);
             $table->timestamps();
         });

--- a/tests/Support/Builders/UserBuilder.php
+++ b/tests/Support/Builders/UserBuilder.php
@@ -29,6 +29,7 @@ class UserBuilder extends EmptyBuilder
     public function filters(): array
     {
         return [
+            'active'     => $this->filter()->expect('bool')->byField('active'),
             'name'       => $this->filter()->expectMany('string')->byField('name'),
             'created_at' => $this->filter()->expect('datetime')->byField('created_at', '>'),
             'posts'      => $this->filter()->expectMany('string')->byAssociation('posts', 'id'),


### PR DESCRIPTION
As mentioned in #15 it will now throw an `InvalidInputException` notifying the consumer of the api that a filter or sort they used does not exist, this prevents them getting a result back that's incorrect but still accepted